### PR TITLE
More reasonably sized headings

### DIFF
--- a/public/assets/wireframe/app.scss
+++ b/public/assets/wireframe/app.scss
@@ -235,27 +235,62 @@ h6 {
   }
 }
 h1 {
-  font-size: 4.242rem;
-  line-height: 4.5rem;
-  margin-top: 3rem;
+  font-size: 1.5rem;
+  line-height: 1.4;
+  margin-top: 0;
+  margin-bottom: 0.5rem; 
 }
+
 h2 {
-  font-size: 2.828rem;
-  line-height: 3rem;
-  margin-top: 3rem;
+  font-size: 1.25rem;
+  line-height: 1.4;
+  margin-top: 0;
+  margin-bottom: 0.5rem; 
 }
 h3 {
-  font-size: 1.414rem;
+  font-size: 1.1875rem;
+  line-height: 1.4;
+  margin-top: 0;
+  margin-bottom: 0.5rem; 
 }
 h4 {
-  font-size: 0.707rem;
+  font-size: 1.125rem;
+  line-height: 1.4;
+  margin-top: 0;
+  margin-bottom: 0.5rem; 
 }
 h5 {
-  font-size: 0.4713333333333333rem;
+  font-size: 1.0625rem;
+  line-height: 1.4;
+  margin-top: 0;
+  margin-bottom: 0.5rem; 
 }
 h6 {
-  font-size: 0.3535rem;
+  font-size: 1rem;
+  line-height: 1.4;
+  margin-top: 0;
+  margin-bottom: 0.5rem; 
 }
+@media print, screen and (min-width: 40em) {
+  h1 {
+    font-size: 3rem; 
+  }
+  h2 {
+    font-size: 2.5rem; 
+  }
+  h3 {
+    font-size: 1.9375rem; 
+  }
+  h4 {
+    font-size: 1.5625rem; 
+  }
+  h5 {
+    font-size: 1.25rem; 
+  }
+  h6 {
+    font-size: 1rem; } 
+}
+
 
 table {
   border: 1px solid #aaa;


### PR DESCRIPTION
Current headings (especially h1) are gigantic. Here's a better balanced, responsive (borrowed from foundation) styling for heading tags.

# Old:

![old](https://user-images.githubusercontent.com/11136895/38117035-ead40494-3380-11e8-812f-cd12042b92f6.png)

# New: 

![new](https://user-images.githubusercontent.com/11136895/38117042-f5022e1e-3380-11e8-9cfa-8686d218199a.PNG)

